### PR TITLE
Fix plugin path

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -10,5 +10,5 @@ where /q node
 IF ERRORLEVEL 1 (
     echo {"result": [{"Title": %title%, "Subtitle": %subtitle%, "IcoPath": "%icon%"}]}
 ) ELSE (
-    node %plugin_dir%/src/main.js %*
+    node "%plugin_dir%/src/main.js" %*
 )


### PR DESCRIPTION
When I try to run this plugin, I get this error `Error: Cannot find module 'path\to\FlowLauncher\Plugins\Translate'`. Node won't find the correct path (`path\to\FlowLauncher\Plugins\Translate Tool-0.1.0`) because it has spaces.